### PR TITLE
Simpler footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
     <!-- <link rel="stylesheet" href="{{ "/assets/css/main.css" | relative_url }}"> -->
   </head>
   <body class="antialiased bg-earth-50">
-    <div class="flex flex-col">
+    <div class="flex flex-col px-4 2xl:px-0">
       {% include navigation.html %}
       {{ content }}
     </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,8 +8,8 @@
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
     <!-- <link rel="stylesheet" href="{{ "/assets/css/main.css" | relative_url }}"> -->
   </head>
-  <body class="antialiased bg-neutral-950">
-    <div class="flex flex-col bg-earth-50">
+  <body class="antialiased bg-earth-50">
+    <div class="flex flex-col">
       {% include navigation.html %}
       {{ content }}
     </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,6 +13,29 @@
       {% include navigation.html %}
       {{ content }}
     </div>
+
+    <footer class="bg-neutral-950 text-white w-full">
+      <div class="max-w-7xl mx-auto flex flex-col gap-y-12 py-18 px-4 2xl:px-0">
+        <div class="grow flex flex-col items-center gap-y-6">
+          <h3 class="text-4xl lg:text-7xl font-medium max-w-2xl text-center text-balance">Kom igang i dag og spar utallige timer</h3>
+          <p>med <span class="font-medium">Tally</span> kan du få bogføringen på autopilot.</p>
+          <div class="flex items-center justify-center">
+            <a href="#" class="text-sm bg-white text-neutral-950 px-4 py-2 rounded-md font-mono">Kom igang</a>
+          </div>
+        </div>
+        <div class="flex items-center justify-between text-xs text-white border-t border-neutral-900 pt-8">
+          <div><span>© {{ "now" | date: "%Y" }} Tally</span></div>
+          <div class="flex items-center gap-x-4">
+            <a class="hover:underline" href="#">Privacy policy</a>
+            <a class="hover:underline" href="#">Terms of service</a>
+          </div>
+          <div class="flex items-center gap-x-4">
+            <a class="hover:underline" href="#">Linkedin</a>
+            <a class="hover:underline" href="#">Email</a>
+          </div>
+        </div>
+      </div>
+    </footer>
  
     <script src="https://unpkg.com/lucide@latest"></script>
     <script>

--- a/index.html
+++ b/index.html
@@ -127,25 +127,3 @@ title: "Tally"
     </div>
   </div>
 </main>
-<footer class="bg-neutral-950 text-white w-full">
-  <div class="max-w-7xl mx-auto flex flex-col gap-y-12 py-18 px-4 xl:px-0">
-    <div class="grow flex flex-col items-center gap-y-6">
-      <h3 class="text-4xl lg:text-7xl font-medium max-w-2xl text-center text-balance">Kom igang i dag og spar utallige timer</h3>
-      <p>med <span class="font-medium">Tally</span> kan du få bogføringen på autopilot.</p>
-      <div class="flex items-center justify-center">
-        <a href="#" class="text-sm bg-white text-neutral-950 px-4 py-2 rounded-md font-mono">Kom igang</a>
-      </div>
-    </div>
-    <div class="flex items-center justify-between text-xs text-white border-t border-neutral-900 pt-8">
-      <div><span>© {{ "now" | date: "%Y" }} Tally</span></div>
-      <div class="flex items-center gap-x-4">
-        <a class="hover:underline" href="#">Privacy policy</a>
-        <a class="hover:underline" href="#">Terms of service</a>
-      </div>
-      <div class="flex items-center gap-x-4">
-        <a class="hover:underline" href="#">Linkedin</a>
-        <a class="hover:underline" href="#">Email</a>
-      </div>
-    </div>
-  </div>
-</footer>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@ layout: default
 title: "Tally"
 ---
 
-<main class="min-h-dvh flex flex-col relative z-20 mb-[100dvh] bg-earth-50">
+<main class="flex flex-col bg-earth-50">
   <div class="">
     <div class="max-w-7xl mx-auto flex flex-col items-center justify-center py-32 pt-18 gap-y-12">
       <div class="flex flex-col items-center gap-y-8">
@@ -127,31 +127,24 @@ title: "Tally"
     </div>
   </div>
 </main>
-<footer class="bg-blue-600 text-white fixed bottom-0 w-full z-10 h-dvh">
-  <div class="h-full w-full relative">
-    <div class="hidden absolute top-0 left-0 w-full h-full grid items-center justify-center ">
-      <span class="text-[40rem] leading-none font-medium text-neutral-700">Tally</span>
+<footer class="bg-neutral-950 text-white w-full">
+  <div class="max-w-7xl mx-auto flex flex-col gap-y-12 py-18 px-4 xl:px-0">
+    <div class="grow flex flex-col items-center gap-y-6">
+      <h3 class="text-4xl lg:text-7xl font-medium max-w-2xl text-center text-balance">Kom igang i dag og spar utallige timer</h3>
+      <p>med <span class="font-medium">Tally</span> kan du få bogføringen på autopilot.</p>
+      <div class="flex items-center justify-center">
+        <a href="#" class="text-sm bg-white text-neutral-950 px-4 py-2 rounded-md font-mono">Kom igang</a>
+      </div>
     </div>
-    <div class="absolute bottom-0 left-0 w-full h-full">
-      <div class="max-w-7xl mx-auto flex flex-col py-18 h-full relative">
-        <div class="grow flex flex-col items-center gap-y-6">
-          <h3 class="text-7xl font-medium max-w-2xl text-center text-balance">Kom igang i dag og spar utallige timer</h3>
-          <p>med <span class="font-medium">Tally</span> kan du få bogføringen på autopilot.</p>
-          <div class="flex items-center justify-center">
-            <a href="#" class="text-sm bg-white text-neutral-950 px-4 py-2 rounded-md font-mono">Kom igang</a>
-          </div>
-        </div>
-        <div class="flex items-center justify-between text-xs text-white">
-          <div><span>© {{ "now" | date: "%Y" }} Tally</span></div>
-          <div class="flex items-center gap-x-4">
-            <a class="hover:underline" href="#">Privacy policy</a>
-            <a class="hover:underline" href="#">Terms of service</a>
-          </div>
-          <div class="flex items-center gap-x-4">
-            <a class="hover:underline" href="#">Linkedin</a>
-            <a class="hover:underline" href="#">Email</a>
-          </div>
-        </div>
+    <div class="flex items-center justify-between text-xs text-white border-t border-neutral-900 pt-8">
+      <div><span>© {{ "now" | date: "%Y" }} Tally</span></div>
+      <div class="flex items-center gap-x-4">
+        <a class="hover:underline" href="#">Privacy policy</a>
+        <a class="hover:underline" href="#">Terms of service</a>
+      </div>
+      <div class="flex items-center gap-x-4">
+        <a class="hover:underline" href="#">Linkedin</a>
+        <a class="hover:underline" href="#">Email</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The current footer is too complex for me, and too big a contrast to the rest of the site's layout. 

Implemented a simpler footer with the same components.

<img width="2558" height="1720" alt="CleanShot 2025-09-18 at 13 07 36@2x" src="https://github.com/user-attachments/assets/09ee10a7-83fe-44ed-bae3-7129b770740f" />